### PR TITLE
Optimization: Increase max threads per block 

### DIFF
--- a/cuda/src/quotients.cu
+++ b/cuda/src/quotients.cu
@@ -38,7 +38,7 @@ void column_sample_batches_for(
         column_sample_batch *result
 ) {
     unsigned int offset = 0;
-    for (unsigned int index = 0; index < sample_size; index++) {
+    for (size_t index = 0; index < sample_size; ++index) {
         result[index].point = sample_points[index];
         result[index].columns = &sample_column_indexes[offset];
         result[index].values = &sample_column_values[offset];
@@ -98,7 +98,7 @@ __device__ void denominator_inverse(
         const point domain_point,
         cm31 *flat_denominators) {
 
-    for (unsigned int i = 0; i < sample_size; i++) {
+    for (size_t i = 0; i < sample_size; ++i) {
         cm31 prx = sample_batches[i].point.x.a;
         cm31 pry = sample_batches[i].point.y.a;
         cm31 pix = sample_batches[i].point.x.b;
@@ -147,13 +147,13 @@ __global__ void accumulate_quotients_in_gpu(
 
         qm31 row_accumulator = {{0, 0}, {0, 0}};
         int line_coeffs_offset = 0;
-        
-        for(int i = 0; i < sample_size; ++i) {
+
+        for(size_t i = 0; i < sample_size; ++i) {
             qm31 *line_coeffs = &flattened_line_coeffs[line_coeffs_offset * 3];
             int line_coeffs_size = line_coeffs_sizes[i];
             qm31 numerator = {{0, 0}, {0, 0}};
 
-            for(int j = 0; j < line_coeffs_size; j++) {
+            for(size_t j = 0; j < line_coeffs_size; ++j) {
                 qm31 a = line_coeffs[3 * j + 0];
                 qm31 b = line_coeffs[3 * j + 1];
                 qm31 c = line_coeffs[3 * j + 2];

--- a/cuda/src/quotients.cu
+++ b/cuda/src/quotients.cu
@@ -38,7 +38,7 @@ void column_sample_batches_for(
         column_sample_batch *result
 ) {
     unsigned int offset = 0;
-    for (size_t index = 0; index < sample_size; ++index) {
+    for (unsigned int index = 0; index < sample_size; ++index) {
         result[index].point = sample_points[index];
         result[index].columns = &sample_column_indexes[offset];
         result[index].values = &sample_column_values[offset];
@@ -98,7 +98,7 @@ __device__ void denominator_inverse(
         const point domain_point,
         cm31 *flat_denominators) {
 
-    for (size_t i = 0; i < sample_size; ++i) {
+    for (unsigned int i = 0; i < sample_size; ++i) {
         cm31 prx = sample_batches[i].point.x.a;
         cm31 pry = sample_batches[i].point.y.a;
         cm31 pix = sample_batches[i].point.x.b;
@@ -148,12 +148,12 @@ __global__ void accumulate_quotients_in_gpu(
         qm31 row_accumulator = {{0, 0}, {0, 0}};
         int line_coeffs_offset = 0;
 
-        for(size_t i = 0; i < sample_size; ++i) {
+        for(int i = 0; i < sample_size; ++i) {
             qm31 *line_coeffs = &flattened_line_coeffs[line_coeffs_offset * 3];
             int line_coeffs_size = line_coeffs_sizes[i];
             qm31 numerator = {{0, 0}, {0, 0}};
 
-            for(size_t j = 0; j < line_coeffs_size; ++j) {
+            for(int j = 0; j < line_coeffs_size; ++j) {
                 qm31 a = line_coeffs[3 * j + 0];
                 qm31 b = line_coeffs[3 * j + 1];
                 qm31 c = line_coeffs[3 * j + 2];

--- a/cuda/src/quotients.cu
+++ b/cuda/src/quotients.cu
@@ -268,6 +268,11 @@ void accumulate_quotients(
     );
     cudaDeviceSynchronize();
 
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        printf("CUDA Error: %s\n", cudaGetErrorString(err));
+    }
+
     free(sample_batches);
     cudaFree(sample_batches_device);
     cudaFree(denominator_inverses);

--- a/stwo_gpu_backend/Cargo.toml
+++ b/stwo_gpu_backend/Cargo.toml
@@ -26,3 +26,11 @@ harness = false
 [[bench]]
 name = "batch_inverse"
 harness = false
+
+[[bench]]
+name = "eval_at_point"
+harness = false
+
+[[bench]]
+name = "quotients"
+harness = false

--- a/stwo_gpu_backend/benches/bit_reverse.rs
+++ b/stwo_gpu_backend/benches/bit_reverse.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use itertools::Itertools;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -6,12 +6,12 @@ use stwo_gpu_backend::{cuda::BaseFieldVec, cuda::SecureFieldVec, CudaBackend};
 use stwo_prover::core::backend::{Column, ColumnOps};
 use stwo_prover::core::fields::{m31::BaseField, qm31::SecureField};
 
-pub fn gpu_bit_reverse_base_field(c: &mut Criterion) {
+pub fn gpu_bit_reverse_base_field_iter(c: &mut Criterion) {
     const BITS: usize = 28;
     let size = 1 << BITS;
     let mut data = BaseFieldVec::from_vec((0..size).map(BaseField::from).collect_vec());
 
-    c.bench_function(&format!("gpu bit_rev base_field {} bit", BITS), |b| {
+    c.bench_function(&format!("gpu bit_rev base_field {} bit single reference", BITS), |b| {
         b.iter(|| {
             <CudaBackend as ColumnOps<BaseField>>::bit_reverse_column(&mut data);
         })
@@ -19,16 +19,86 @@ pub fn gpu_bit_reverse_base_field(c: &mut Criterion) {
 }
 
 pub fn gpu_bit_reverse_secure_field(c: &mut Criterion) {
-    const BITS: usize = 28;
+    const BITS: usize = 26;
     let size = 1 << BITS;
 
     let mut rng = SmallRng::seed_from_u64(0);
-    let mut data = SecureFieldVec::from_vec((0..size).map(|_| rng.gen()).collect());
+    let data = SecureFieldVec::from_vec((0..size).map(|_| rng.gen()).collect());
     assert_eq!(data.len(), size);
 
     c.bench_function(&format!("gpu bit_rev secure_field {} bit", BITS), |b| {
+        b.iter_batched(||  data.clone(), 
+            |mut data| <CudaBackend as ColumnOps<SecureField>>::bit_reverse_column(&mut data),
+            BatchSize::PerIteration 
+        );
+    });
+}
+
+pub fn gpu_bit_reverse_base_field_with_large_drop(c: &mut Criterion) {
+    const BITS: usize = 28;
+    let size = 1 << BITS;
+    let data = BaseFieldVec::from_vec((0..size).map(BaseField::from).collect_vec());
+
+    c.bench_function(&format!("gpu bit_rev base_field with large drop {} bit", BITS), |b| {
+        b.iter_with_large_drop(|| {
+            let mut data = data.clone();
+            move || {
+                <CudaBackend as ColumnOps<BaseField>>::bit_reverse_column(&mut data)
+            }
+        });
+    });
+}
+
+pub fn gpu_bit_reverse_base_field_iter_batched_dtd_copy(c: &mut Criterion) {
+    const BITS: usize = 28;
+    let size = 1 << BITS;
+    let data = BaseFieldVec::from_vec((0..size).map(BaseField::from).collect_vec());
+
+    c.bench_function(&format!("gpu bit_rev base_field {} bit multiple setup dtd", BITS), |b| {
+        b.iter_batched(|| 
+            data.clone(), 
+            |mut data| <CudaBackend as ColumnOps<BaseField>>::bit_reverse_column(&mut data),
+            BatchSize::PerIteration, 
+        );
+    });
+}
+
+pub fn gpu_bit_reverse_base_field_iter_batched_htd_copy(c: &mut Criterion) {
+    const BITS: usize = 28;
+    let size = 1 << BITS;
+    //let data = BaseFieldVec::from_vec((0..size).map(BaseField::from).collect_vec());
+
+    c.bench_function(&format!("gpu bit_rev base_field {} bit multiple setup htd", BITS), |b| {
+        b.iter_batched(|| 
+            BaseFieldVec::from_vec((0..size).map(BaseField::from).collect_vec()).clone(), 
+            |mut data| <CudaBackend as ColumnOps<BaseField>>::bit_reverse_column(&mut data),
+            BatchSize::PerIteration, 
+        );
+    });
+}
+
+pub fn gpu_bit_reverse_base_field_iter_initializing(c: &mut Criterion) {
+    const BITS: usize = 28;
+    let size = 1 << BITS;
+    let vec = (0..size).map(BaseField::from).collect_vec();
+
+    c.bench_function(&format!("gpu bit_rev base_field {} bit initializing", BITS), |b| {
+        b.iter_with_setup(
+            || vec.clone(),
+            |cloned_vec| BaseFieldVec::from_vec(cloned_vec)
+        )
+    });
+}
+
+pub fn gpu_bit_reverse_base_field_iter_cloning(c: &mut Criterion) {
+    const BITS: usize = 28;
+    let size = 1 << BITS;
+    let data = BaseFieldVec::from_vec((0..size).map(BaseField::from).collect_vec());
+
+    c.bench_function(&format!("gpu bit_rev base_field {} bit cloning", BITS), |b| {
         b.iter(|| {
-            <CudaBackend as ColumnOps<SecureField>>::bit_reverse_column(&mut data);
+            let _ = data.clone();
+            
         })
     });
 }
@@ -36,5 +106,5 @@ pub fn gpu_bit_reverse_secure_field(c: &mut Criterion) {
 criterion_group!(
     name = bit_reverse;
     config = Criterion::default().sample_size(10);
-    targets = gpu_bit_reverse_base_field, gpu_bit_reverse_secure_field);
+    targets = gpu_bit_reverse_base_field_iter_initializing,gpu_bit_reverse_base_field_iter_cloning); // gpu_bit_reverse_base_field_iter, gpu_bit_reverse_base_field_with_large_drop, gpu_bit_reverse_base_field_iter_batched_dtd_copy, gpu_bit_reverse_base_field_iter_batched_htd_copy); //, gpu_bit_reverse_secure_field);
 criterion_main!(bit_reverse);

--- a/stwo_gpu_backend/benches/bit_reverse.rs
+++ b/stwo_gpu_backend/benches/bit_reverse.rs
@@ -35,9 +35,9 @@ pub fn gpu_bit_reverse_secure_field(c: &mut Criterion) {
 
 pub fn cpu_bit_rev(c: &mut Criterion) {
     use stwo_prover::core::utils::bit_reverse;
-    // TODO(andrew): Consider using same size for all.
     const BITS: usize = 28;
     let size = 1 << BITS;
+
     let data = (0..size).map(BaseField::from).collect_vec();
     c.bench_function(&format!("cpu bit_rev {} bit", BITS), |b| {
         b.iter_batched(
@@ -51,6 +51,7 @@ pub fn cpu_bit_rev(c: &mut Criterion) {
 pub fn simd_bit_rev(c: &mut Criterion) {
     use stwo_prover::core::backend::simd::bit_reverse::bit_reverse_m31;
     use stwo_prover::core::backend::simd::column::BaseColumn;
+    
     const BITS: usize = 28;
     let size = 1 << BITS;
     let data = (0..size).map(BaseField::from).collect::<BaseColumn>();
@@ -80,7 +81,6 @@ pub fn gpu_bit_reverse_base_field_iter_batched_dtd_copy(c: &mut Criterion) {
 pub fn gpu_bit_reverse_base_field_iter_batched_htd_copy(c: &mut Criterion) {
     const BITS: usize = 28;
     let size = 1 << BITS;
-    //let data = BaseFieldVec::from_vec((0..size).map(BaseField::from).collect_vec());
 
     c.bench_function(&format!("gpu bit_rev base_field {} bit multiple setup htd", BITS), |b| {
         b.iter_batched(|| 
@@ -91,34 +91,8 @@ pub fn gpu_bit_reverse_base_field_iter_batched_htd_copy(c: &mut Criterion) {
     });
 }
 
-pub fn gpu_bit_reverse_base_field_iter_initializing(c: &mut Criterion) {
-    const BITS: usize = 28;
-    let size = 1 << BITS;
-    let vec = (0..size).map(BaseField::from).collect_vec();
-
-    c.bench_function(&format!("gpu bit_rev base_field {} bit initializing", BITS), |b| {
-        b.iter_with_setup(
-            || vec.clone(),
-            |cloned_vec| BaseFieldVec::from_vec(cloned_vec)
-        )
-    });
-}
-
-pub fn gpu_bit_reverse_base_field_iter_cloning(c: &mut Criterion) {
-    const BITS: usize = 28;
-    let size = 1 << BITS;
-    let data = BaseFieldVec::from_vec((0..size).map(BaseField::from).collect_vec());
-
-    c.bench_function(&format!("gpu bit_rev base_field {} bit cloning", BITS), |b| {
-        b.iter(|| {
-            let _ = data.clone();
-            
-        })
-    });
-}
-
 criterion_group!(
     name = bit_reverse;
     config = Criterion::default().sample_size(10);
-    targets = cpu_bit_rev, simd_bit_rev, gpu_bit_reverse_base_field_iter_batched_dtd_copy, gpu_bit_reverse_base_field_iter_batched_htd_copy); //, gpu_bit_reverse_secure_field);
+    targets = cpu_bit_rev, simd_bit_rev, gpu_bit_reverse_base_field_iter_batched_dtd_copy, gpu_bit_reverse_base_field_iter_batched_htd_copy, gpu_bit_reverse_secure_field);
 criterion_main!(bit_reverse);

--- a/stwo_gpu_backend/benches/eval_at_point.rs
+++ b/stwo_gpu_backend/benches/eval_at_point.rs
@@ -1,0 +1,37 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use stwo_gpu_backend::CudaBackend;
+use stwo_prover::core::backend::cpu::CpuBackend;
+use stwo_prover::core::backend::simd::SimdBackend;
+use stwo_prover::core::circle::CirclePoint;
+use stwo_prover::core::fields::m31::BaseField;
+use stwo_prover::core::poly::circle::{CirclePoly, PolyOps};
+
+const LOG_SIZE: u32 = 20;
+
+fn bench_eval_at_secure_point<B: PolyOps>(c: &mut Criterion, id: &str) {
+    let poly = CirclePoly::new((0..1 << LOG_SIZE).map(BaseField::from).collect());
+    let mut rng = SmallRng::seed_from_u64(0);
+    let x = rng.gen();
+    let y = rng.gen();
+    let point = CirclePoint { x, y };
+    c.bench_function(
+        &format!("{id} eval_at_secure_field_point 2^{LOG_SIZE}"),
+        |b| {
+            b.iter(|| B::eval_at_point(black_box(&poly), black_box(point)));
+        },
+    );
+}
+
+fn eval_at_secure_point_benches(c: &mut Criterion) {
+    bench_eval_at_secure_point::<SimdBackend>(c, "simd");
+    bench_eval_at_secure_point::<CpuBackend>(c, "cpu");
+    bench_eval_at_secure_point::<CudaBackend>(c, "cuda");
+}
+
+criterion_group!(
+        name = eval_at_point;
+        config = Criterion::default().sample_size(10);
+        targets = eval_at_secure_point_benches);
+criterion_main!(eval_at_point);

--- a/stwo_gpu_backend/benches/quotients.rs
+++ b/stwo_gpu_backend/benches/quotients.rs
@@ -44,9 +44,9 @@ fn bench_quotients<B: QuotientOps, const LOG_N_ROWS: u32, const LOG_N_COLS: u32>
 }
 
 fn quotients_benches(c: &mut Criterion) {
-    bench_quotients::<SimdBackend, 20, 8>(c, "simd");
-    bench_quotients::<CpuBackend, 20, 8>(c, "cpu");
-    bench_quotients::<CudaBackend, 20, 8>(c, "cuda");
+   //bench_quotients::<SimdBackend, 20, 8>(c, "simd");
+    //bench_quotients::<CpuBackend, 20, 8>(c, "cpu");
+    bench_quotients::<CudaBackend, 28, 16>(c, "cuda");
 }
 
 criterion_group!(

--- a/stwo_gpu_backend/benches/quotients.rs
+++ b/stwo_gpu_backend/benches/quotients.rs
@@ -12,7 +12,6 @@ use stwo_prover::core::pcs::quotients::{ColumnSampleBatch, QuotientOps};
 use stwo_prover::core::poly::circle::{CanonicCoset, CircleEvaluation};
 use stwo_prover::core::poly::BitReversedOrder;
 
-// TODO(andrew): Consider removing const generics and making all sizes the same.
 fn bench_quotients<B: QuotientOps, const LOG_N_ROWS: u32, const LOG_N_COLS: u32>(
     c: &mut Criterion,
     id: &str,
@@ -46,7 +45,7 @@ fn bench_quotients<B: QuotientOps, const LOG_N_ROWS: u32, const LOG_N_COLS: u32>
 fn quotients_benches(c: &mut Criterion) {
    //bench_quotients::<SimdBackend, 20, 8>(c, "simd");
     //bench_quotients::<CpuBackend, 20, 8>(c, "cpu");
-    bench_quotients::<CudaBackend, 28, 16>(c, "cuda");
+    bench_quotients::<CudaBackend, 20, 8>(c, "cuda");
 }
 
 criterion_group!(

--- a/stwo_gpu_backend/benches/quotients.rs
+++ b/stwo_gpu_backend/benches/quotients.rs
@@ -1,0 +1,56 @@
+#![feature(iter_array_chunks)]
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+use stwo_gpu_backend::CudaBackend;
+use stwo_prover::core::backend::cpu::CpuBackend;
+use stwo_prover::core::backend::simd::SimdBackend;
+use stwo_prover::core::circle::SECURE_FIELD_CIRCLE_GEN;
+use stwo_prover::core::fields::m31::BaseField;
+use stwo_prover::core::fields::qm31::SecureField;
+use stwo_prover::core::pcs::quotients::{ColumnSampleBatch, QuotientOps};
+use stwo_prover::core::poly::circle::{CanonicCoset, CircleEvaluation};
+use stwo_prover::core::poly::BitReversedOrder;
+
+// TODO(andrew): Consider removing const generics and making all sizes the same.
+fn bench_quotients<B: QuotientOps, const LOG_N_ROWS: u32, const LOG_N_COLS: u32>(
+    c: &mut Criterion,
+    id: &str,
+) {
+    let domain = CanonicCoset::new(LOG_N_ROWS).circle_domain();
+    let values = (0..domain.size()).map(BaseField::from).collect();
+    let col = CircleEvaluation::<B, BaseField, BitReversedOrder>::new(domain, values);
+    let cols = (0..1 << LOG_N_COLS).map(|_| col.clone()).collect_vec();
+    let col_refs = cols.iter().collect_vec();
+    let random_coeff = SecureField::from_u32_unchecked(0, 1, 2, 3);
+    let a = SecureField::from_u32_unchecked(5, 6, 7, 8);
+    let samples = vec![ColumnSampleBatch {
+        point: SECURE_FIELD_CIRCLE_GEN,
+        columns_and_values: (0..1 << LOG_N_COLS).map(|i| (i, a)).collect(),
+    }];
+    c.bench_function(
+        &format!("{id} quotients 2^{LOG_N_COLS} x 2^{LOG_N_ROWS}"),
+        |b| {
+            b.iter_with_large_drop(|| {
+                B::accumulate_quotients(
+                    black_box(domain),
+                    black_box(&col_refs),
+                    black_box(random_coeff),
+                    black_box(&samples),
+                )
+            })
+        },
+    );
+}
+
+fn quotients_benches(c: &mut Criterion) {
+    bench_quotients::<SimdBackend, 20, 8>(c, "simd");
+    bench_quotients::<CpuBackend, 20, 8>(c, "cpu");
+    bench_quotients::<CudaBackend, 20, 8>(c, "cuda");
+}
+
+criterion_group!(
+    name = quotients;
+    config = Criterion::default().sample_size(10);
+    targets = quotients_benches);
+criterion_main!(quotients);

--- a/stwo_gpu_backend/src/column.rs
+++ b/stwo_gpu_backend/src/column.rs
@@ -4,7 +4,7 @@ use stwo_prover::core::{
 };
 use stwo_prover::core::vcs::blake2_hash::Blake2sHash;
 
-use crate::{backend::CudaBackend, cuda};
+use crate::{backend::CudaBackend, cuda::{self, BaseFieldVec}};
 
 impl ColumnOps<BaseField> for CudaBackend {
     type Column = cuda::BaseFieldVec;
@@ -56,8 +56,9 @@ impl Column<BaseField> for cuda::BaseFieldVec {
 }
 
 impl FromIterator<BaseField> for cuda::BaseFieldVec {
-    fn from_iter<T: IntoIterator<Item = BaseField>>(_iter: T) -> Self {
-        todo!()
+    fn from_iter<T: IntoIterator<Item = BaseField>>(iter: T) -> Self {
+        let vec: Vec<BaseField> = iter.into_iter().collect();
+        BaseFieldVec::from_vec(vec)
     }
 }
 


### PR DESCRIPTION
Quotient operations increased in performance (2^20 x 2^8 column) by ~20% for rtx4070 laptop. 

* Increased the max thread count per block (512 -> 1024) by reducing register strain in the quotients kernel. Specifically, in-lining a single address reference before the line coefficient calculation loop frees up 8 registers.

* Also included are a few more benchmark functions, and minor cleans.