### PR TITLE
Add example for Wide Fibonacci with Cuda constraints

### DIFF
--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(gpubackend SHARED
         src/example.cu
         src/gkr.cu
         src/mle.cu
+        src/examples/wide_fibonacci.cu
 )
 target_compile_options(gpubackend PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:
         -arch=sm_50;

--- a/cuda/include/examples/wide_fibonacci.cuh
+++ b/cuda/include/examples/wide_fibonacci.cuh
@@ -1,0 +1,17 @@
+#ifndef WIDE_FIBONACCI_H
+#define WIDE_FIBONACCI_H
+
+#include "fields.cuh"
+#include "utils.cuh"
+
+extern "C"
+void evaluate_wide_fibonacci_constraint_quotients_on_domain(
+    m31 *quotients_0, m31 *quotients_1, m31 *quotients_2, m31 *quotients_3,
+    m31 **trace_evaluations,
+    qm31 *random_coeff_powers,
+    m31 *denominator_inverses,
+    unsigned int extended_domain_size,
+    unsigned int number_of_columns
+);
+
+#endif // WIDE_FIBONACCI_H

--- a/cuda/include/fields.cuh
+++ b/cuda/include/fields.cuh
@@ -32,6 +32,8 @@ __host__ __device__ uint64_t pow_to_power_of_two(int n, m31 t);
 
 __host__ __device__ m31 inv(m31 t);
 
+__host__ __device__ m31 square(m31 x);
+
 /*##### CM31 ##### */
 
 __host__ __device__ cm31 mul(cm31 x, cm31 y);

--- a/cuda/src/examples/wide_fibonacci.cu
+++ b/cuda/src/examples/wide_fibonacci.cu
@@ -1,0 +1,66 @@
+#include "../../include/examples/wide_fibonacci.cuh"
+
+__global__ void evaluate_wide_fibonacci_constraint_quotients_kernel(
+    m31 *quotients_0, m31 *quotients_1, m31 *quotients_2, m31 *quotients_3,
+    m31 **trace_evaluations,
+    qm31 *numerators,
+    qm31 *random_coeff_powers,
+    m31 *denominator_inverses,
+    unsigned int number_of_columns
+) {
+    unsigned int row_index = blockIdx.x * blockDim.x + threadIdx.x;
+
+    for(unsigned int constraint_index = 0; constraint_index < number_of_columns - 2; constraint_index++) {
+        numerators[row_index] = add(
+            numerators[row_index],
+            mul(
+                sub(
+                    add(
+                        square(trace_evaluations[constraint_index][row_index]),
+                        square(trace_evaluations[constraint_index + 1][row_index])
+                    ),
+                    trace_evaluations[constraint_index + 2][row_index]
+                ),
+                random_coeff_powers[number_of_columns - 3 - constraint_index]
+            )
+        );
+    }
+
+    qm31 constraint_quotient = mul(
+        denominator_inverses[row_index],
+        numerators[row_index]
+    );
+
+    quotients_0[row_index] = constraint_quotient.a.a;
+    quotients_1[row_index] = constraint_quotient.a.b;
+    quotients_2[row_index] = constraint_quotient.b.a;
+    quotients_3[row_index] = constraint_quotient.b.b;
+}
+
+void evaluate_wide_fibonacci_constraint_quotients_on_domain(
+    m31 *quotients_0, m31 *quotients_1, m31 *quotients_2, m31 *quotients_3,
+    m31 **trace_evaluations,
+    qm31 *random_coeff_powers,
+    m31 *denominator_inverses,
+    unsigned int extended_domain_size,
+    unsigned int number_of_columns
+) {
+    m31 **device_trace_evaluations = clone_to_device<m31*>(trace_evaluations, extended_domain_size);
+    qm31 *numerators = (qm31*) cuda_alloc_zeroes_uint32_t(4 * extended_domain_size);
+
+    unsigned int block_size = 1024;
+    unsigned int number_of_blocks = (extended_domain_size + block_size - 1) / block_size;
+
+    evaluate_wide_fibonacci_constraint_quotients_kernel<<<block_size, number_of_blocks>>>(
+        quotients_0, quotients_1, quotients_2, quotients_3,
+        device_trace_evaluations,
+        numerators,
+        random_coeff_powers,
+        denominator_inverses,
+        number_of_columns
+    );
+    cudaDeviceSynchronize();
+
+    cuda_free_memory(device_trace_evaluations);
+    cuda_free_memory(numerators);
+}

--- a/cuda/src/fields.cu
+++ b/cuda/src/fields.cu
@@ -39,6 +39,10 @@ __host__ __device__ m31 inv(m31 t) {
     return mul(pow_to_power_of_two(7, t5), t2);
 }
 
+__host__ __device__ m31 square(m31 x) {
+    return mul(x, x); 
+}
+
 /*##### CM31 ##### */
 
 __host__ __device__ cm31 mul(cm31 x, cm31 y) {

--- a/stwo_gpu_backend/benches/interpolate_columns.rs
+++ b/stwo_gpu_backend/benches/interpolate_columns.rs
@@ -7,7 +7,6 @@ use stwo_prover::core::fields::m31::BaseField;
 use stwo_prover::core::poly::circle::{CanonicCoset, CircleEvaluation, PolyOps};
 use stwo_prover::core::poly::BitReversedOrder;
 
-
 const LOG_COLUMN_SIZE: u32 = 10;
 const LOG_NUMBER_OF_COLUMNS: usize = 16;
 
@@ -21,39 +20,32 @@ pub fn simd_interpolate_columns(c: &mut Criterion) {
         SimdBackend::new_canonical_ordered(coset, values);
     let evaluations = vec![circle_evaluation; 1 << LOG_NUMBER_OF_COLUMNS];
 
-    group.bench_function(
-        BenchmarkId::new("simd interpolate", LOG_COLUMN_SIZE),
-        |b| {
-            b.iter_batched(
-                || evaluations.clone(),
-                |evaluations| SimdBackend::interpolate_columns(evaluations, &twiddle_tree),
-                BatchSize::LargeInput,
-            )
-        },
-    );
+    group.bench_function(BenchmarkId::new("simd interpolate", LOG_COLUMN_SIZE), |b| {
+        b.iter_batched(
+            || evaluations.clone(),
+            |evaluations| SimdBackend::interpolate_columns(evaluations, &twiddle_tree),
+            BatchSize::LargeInput,
+        )
+    });
 }
 
 pub fn gpu_interpolate_columns(c: &mut Criterion) {
     let mut group = c.benchmark_group("interpolate_columns");
 
     let coset = CanonicCoset::new(LOG_COLUMN_SIZE);
-    let values =
-        BaseFieldVec::from_vec((0..coset.size()).map(BaseField::from).collect_vec());
+    let values = BaseFieldVec::from_vec((0..coset.size()).map(BaseField::from).collect_vec());
     let twiddle_tree = CudaBackend::precompute_twiddles(coset.half_coset());
     let circle_evaluation: CircleEvaluation<CudaBackend, BaseField, BitReversedOrder> =
         CudaBackend::new_canonical_ordered(coset, values);
     let evaluations = vec![circle_evaluation; 1 << LOG_NUMBER_OF_COLUMNS];
 
-    group.bench_function(
-        BenchmarkId::new("gpu interpolate", LOG_COLUMN_SIZE),
-        |b| {
-            b.iter_batched(
-                || evaluations.clone(),
-                |evaluations| CudaBackend::interpolate_columns(evaluations, &twiddle_tree),
-                BatchSize::LargeInput,
-            )
-        },
-    );
+    group.bench_function(BenchmarkId::new("gpu interpolate", LOG_COLUMN_SIZE), |b| {
+        b.iter_batched(
+            || evaluations.clone(),
+            |evaluations| CudaBackend::interpolate_columns(evaluations, &twiddle_tree),
+            BatchSize::LargeInput,
+        )
+    });
 }
 
 criterion_group!(

--- a/stwo_gpu_backend/src/backend.rs
+++ b/stwo_gpu_backend/src/backend.rs
@@ -18,5 +18,3 @@ impl GrindOps<Blake2sChannel> for CudaBackend {
 }
 
 impl BackendForChannel<Blake2sMerkleChannel> for CudaBackend {}
-
-

--- a/stwo_gpu_backend/src/cuda/bindings.rs
+++ b/stwo_gpu_backend/src/cuda/bindings.rs
@@ -1,9 +1,9 @@
+use std::ffi::c_void;
 use stwo_prover::core::vcs::blake2_hash::Blake2sHash;
 use stwo_prover::core::{
     circle::CirclePoint,
     fields::{m31::BaseField, qm31::SecureField},
 };
-use std::ffi::c_void;
 
 #[repr(C)]
 pub struct CudaSecureField {
@@ -35,7 +35,7 @@ impl From<SecureField> for CudaSecureField {
     }
 }
 
-impl From<CudaSecureField> for SecureField{
+impl From<CudaSecureField> for SecureField {
     fn from(value: CudaSecureField) -> Self {
         SecureField::from_m31(value.a, value.b, value.c, value.d)
     }
@@ -255,5 +255,17 @@ extern "C" {
         evals_size: usize,
         assignment: CudaSecureField,
         output_evals: *const u32,
+    );
+
+    pub fn evaluate_wide_fibonacci_constraint_quotients_on_domain(
+        quotients_0: *const u32,
+        quotients_1: *const u32,
+        quotients_2: *const u32,
+        quotients_3: *const u32,
+        trace_evaluations: *const *const u32,
+        random_coeff_powers: *const u32,
+        denominator_inverses: *const u32,
+        extended_domain_size: u32,
+        number_of_columns: u32,
     );
 }

--- a/stwo_gpu_backend/src/examples/wide_fibonacci.rs
+++ b/stwo_gpu_backend/src/examples/wide_fibonacci.rs
@@ -1,0 +1,249 @@
+use itertools::Itertools;
+use stwo_prover::core::air::accumulation::{
+    DomainEvaluationAccumulator, PointEvaluationAccumulator,
+};
+use stwo_prover::core::air::mask::fixed_mask_points;
+use stwo_prover::core::air::{Component, ComponentProver, Trace};
+use stwo_prover::core::circle::CirclePoint;
+use stwo_prover::core::constraints::coset_vanishing;
+use stwo_prover::core::fields::m31::BaseField;
+use stwo_prover::core::fields::qm31::SecureField;
+use stwo_prover::core::fields::FieldExpOps;
+use stwo_prover::core::pcs::TreeVec;
+use stwo_prover::core::poly::circle::CanonicCoset;
+use stwo_prover::core::ColumnVec;
+
+use crate::cuda::{bindings, BaseFieldVec, SecureFieldVec};
+use crate::CudaBackend;
+
+pub const LOG_N_COLUMNS: usize = 10;
+pub const N_COLUMNS: usize = 1 << LOG_N_COLUMNS;
+
+/// Component that computes 2^`self.log_n_instances` instances of fibonacci sequences of size
+/// 2^`self.log_fibonacci_size`. The numbers are computes over [N_COLUMNS] trace columns. The
+/// number of rows (i.e the size of the columns) is determined by the parameters above (see
+/// [WideFibComponent::log_column_size()]).
+pub struct WideFibComponent {
+    pub log_fibonacci_size: u32,
+    pub log_n_instances: u32,
+}
+
+impl WideFibComponent {
+    /// Returns the log of the size of the columns in the trace (which could also be looked at as
+    /// the log number of rows).
+    pub fn log_column_size(&self) -> u32 {
+        self.log_n_instances as u32
+    }
+
+    pub fn n_columns(&self) -> usize {
+        N_COLUMNS
+    }
+}
+
+impl Component for WideFibComponent {
+    fn n_constraints(&self) -> usize {
+        self.n_columns() - 2
+    }
+
+    fn max_constraint_log_degree_bound(&self) -> u32 {
+        self.log_column_size() + 1
+    }
+
+    fn trace_log_degree_bounds(&self) -> TreeVec<Vec<u32>> {
+        TreeVec(vec![vec![self.log_column_size(); self.n_columns()]])
+    }
+
+    fn mask_points(
+        &self,
+        point: CirclePoint<SecureField>,
+    ) -> TreeVec<ColumnVec<Vec<CirclePoint<SecureField>>>> {
+        TreeVec(vec![fixed_mask_points(
+            &vec![vec![0_usize]; self.n_columns()],
+            point,
+        )])
+    }
+
+    fn evaluate_constraint_quotients_at_point(
+        &self,
+        point: CirclePoint<SecureField>,
+        mask: &TreeVec<ColumnVec<Vec<SecureField>>>,
+        evaluation_accumulator: &mut PointEvaluationAccumulator,
+    ) {
+        let constraint_zero_domain = CanonicCoset::new(self.log_column_size()).coset;
+        let denom = coset_vanishing(constraint_zero_domain, point);
+        let denom_inverse = denom.inverse();
+        for i in 0..self.n_columns() - 2 {
+            let numerator =
+                mask.0[0][i][0].square() + mask.0[0][i + 1][0].square() - mask.0[0][i + 2][0];
+            evaluation_accumulator.accumulate(numerator * denom_inverse);
+        }
+    }
+}
+
+// Input for the fibonacci claim.
+#[derive(Debug, Clone, Copy)]
+pub struct Input {
+    pub a: BaseField,
+    pub b: BaseField,
+}
+
+impl ComponentProver<CudaBackend> for WideFibComponent {
+    fn evaluate_constraint_quotients_on_domain(
+        &self,
+        trace: &Trace<'_, CudaBackend>,
+        evaluation_accumulator: &mut DomainEvaluationAccumulator<CudaBackend>,
+    ) {
+        let ext_domain_log_size = self.max_constraint_log_degree_bound();
+        let ext_domain = CanonicCoset::new(ext_domain_log_size).circle_domain();
+        let trace_evals_ext_domain = &trace.evals[0];
+        let zero_domain = CanonicCoset::new(self.log_column_size()).coset;
+
+        let mut denominators = vec![];
+        for point in ext_domain.iter() {
+            denominators.push(coset_vanishing(zero_domain, point));
+        }
+
+        let gpu_denominators = BaseFieldVec::from_vec(denominators);
+        unsafe {
+            bindings::bit_reverse_base_field(gpu_denominators.device_ptr, ext_domain.size());
+        }
+        let denominator_inverses = BaseFieldVec::new_zeroes(ext_domain.size());
+        unsafe {
+            bindings::batch_inverse_base_field(
+                gpu_denominators.device_ptr,
+                denominator_inverses.device_ptr,
+                ext_domain.size(),
+            );
+        }
+
+        let [column_accumulator] =
+            evaluation_accumulator.columns([(ext_domain_log_size, self.n_constraints())]);
+        let trace_evaluations_vec = trace_evals_ext_domain
+            .iter()
+            .map(|column_evaluations| column_evaluations.device_ptr)
+            .collect_vec();
+        let random_coeff_powers = SecureFieldVec::from_vec(column_accumulator.random_coeff_powers);
+
+        unsafe {
+            bindings::evaluate_wide_fibonacci_constraint_quotients_on_domain(
+                column_accumulator.col.columns[0].device_ptr,
+                column_accumulator.col.columns[1].device_ptr,
+                column_accumulator.col.columns[2].device_ptr,
+                column_accumulator.col.columns[3].device_ptr,
+                trace_evaluations_vec.as_ptr(),
+                random_coeff_powers.device_ptr,
+                denominator_inverses.device_ptr,
+                ext_domain.size() as u32,
+                self.n_columns() as u32,
+            );
+        };
+    }
+}
+
+mod test {
+    use itertools::Itertools;
+    use num_traits::{One, Zero};
+    use stwo_prover::core::{
+        air::Component,
+        channel::Blake2sChannel,
+        fields::{m31::BaseField, FieldExpOps},
+        pcs::{CommitmentSchemeProver, CommitmentSchemeVerifier, PcsConfig},
+        poly::{
+            circle::{CanonicCoset, CircleEvaluation, PolyOps},
+            BitReversedOrder,
+        },
+        prover::{prove, verify},
+        vcs::blake2_merkle::Blake2sMerkleChannel,
+        ColumnVec,
+    };
+
+    use crate::{cuda::BaseFieldVec, examples::wide_fibonacci::LOG_N_COLUMNS, CudaBackend};
+
+    use super::{Input, WideFibComponent, N_COLUMNS};
+
+    /// Generates the trace for the wide Fibonacci example.
+    fn generate_test_trace(
+        log_n_instances: u32,
+    ) -> ColumnVec<CircleEvaluation<CudaBackend, BaseField, BitReversedOrder>> {
+        let inputs: Vec<Input> = (0..1 << log_n_instances)
+            .map(|i| Input {
+                a: BaseField::one(),
+                b: BaseField::from(i),
+            })
+            .collect();
+
+        let mut trace = vec![vec![BaseField::zero(); inputs.len()]; N_COLUMNS];
+        for (index, input) in inputs.iter().enumerate() {
+            write_trace_row(&mut trace, input, index);
+        }
+
+        let domain = CanonicCoset::new(log_n_instances).circle_domain();
+        trace
+            .into_iter()
+            .map(|column| {
+                CircleEvaluation::<_, _, BitReversedOrder>::new(
+                    domain,
+                    BaseFieldVec::from_vec(column),
+                )
+            })
+            .collect_vec()
+    }
+
+    /// Writes the trace row for the wide Fibonacci example to dst, given a private input. Returns the
+    /// last two elements of the row in case the sequence is continued.
+    pub fn write_trace_row(dst: &mut [Vec<BaseField>], private_input: &Input, row_index: usize) {
+        let n_columns = dst.len();
+        dst[0][row_index] = private_input.a;
+        dst[1][row_index] = private_input.b;
+        for i in 2..n_columns {
+            dst[i][row_index] = dst[i - 1][row_index].square() + dst[i - 2][row_index].square();
+        }
+    }
+
+    #[test_log::test]
+    fn test_cuda_constraints_for_wide_fib_prove() {
+        // Note: To see time measurement, run test with
+        //   RUST_LOG_SPAN_EVENTS=enter,close RUST_LOG=info RUST_BACKTRACE=1
+        //   RUSTFLAGS="-Awarnings -C target-cpu=native -C target-feature=+avx2 -C opt-level=3"
+        //   cargo test test_cuda_constraints_for_wide_fib_prove -- --nocapture
+        const LOG_N_INSTANCES: u32 = 16;
+
+        let config = PcsConfig::default();
+
+        // Precompute twiddles.
+        let twiddles = CudaBackend::precompute_twiddles(
+            CanonicCoset::new(LOG_N_INSTANCES + 1 + config.fri_config.log_blowup_factor)
+                .circle_domain()
+                .half_coset,
+        );
+
+        // Setup protocol.
+        let prover_channel = &mut Blake2sChannel::default();
+        let commitment_scheme =
+            &mut CommitmentSchemeProver::<CudaBackend, Blake2sMerkleChannel>::new(
+                config, &twiddles,
+            );
+
+        // Trace.
+        let trace = generate_test_trace(LOG_N_INSTANCES);
+        let mut tree_builder = commitment_scheme.tree_builder();
+        tree_builder.extend_evals(trace);
+        tree_builder.commit(prover_channel);
+
+        let component = WideFibComponent {
+            log_fibonacci_size: LOG_N_COLUMNS as u32,
+            log_n_instances: LOG_N_INSTANCES,
+        };
+
+        let proof =
+            prove::<CudaBackend, _>(&[&component], prover_channel, commitment_scheme).unwrap();
+
+        // Verify.
+        let verifier_channel = &mut Blake2sChannel::default();
+        let commitment_scheme = &mut CommitmentSchemeVerifier::<Blake2sMerkleChannel>::new(config);
+
+        let sizes = component.trace_log_degree_bounds();
+        commitment_scheme.commit(proof.commitments[0], &sizes[0], verifier_channel);
+        verify(&[&component], verifier_channel, commitment_scheme, proof).unwrap();
+    }
+}

--- a/stwo_gpu_backend/src/quotient.rs
+++ b/stwo_gpu_backend/src/quotient.rs
@@ -110,7 +110,6 @@ impl QuotientOps for CudaBackend {
             bindings::cuda_free_memory(device_column_pointers as *const c_void);
         }
 
-
         result
     }
 }


### PR DESCRIPTION
Added an example for Wide Fibonacci, but using a component that implements the Fibonacci constraints in Cuda, and takes advantage of GPU parallelization. It results in a shorter proving time and makes for an interesting benchmark.